### PR TITLE
Fix mgpu init issue with new version of keras

### DIFF
--- a/keras_exp/multigpu/_multigpu.py
+++ b/keras_exp/multigpu/_multigpu.py
@@ -185,6 +185,7 @@ class ModelMGPU(Model):
         # except KeyError:
         #     raise RuntimeError('Keyword argument "model_creator" required '
         #                        'for ModelMGPU.')
+        super(ModelMGPU, self).__init__()
 
         try:
             smodel = kwargs.pop('serial_model')


### PR DESCRIPTION
Ran into this issue while using `keras_experiments` as a multi-GPU benchmark with newer version of keras (2.2.0). 

```
RuntimeError: It looks like you are subclassing `Model` and you forgot to call `super(YourClass, self).__init__()`. Always start with this line.
```

Adding this line seems to solve the issue.